### PR TITLE
Fix routing for admin/content.

### DIFF
--- a/file_entity.links.menu.yml
+++ b/file_entity.links.menu.yml
@@ -1,3 +1,9 @@
+entity.file.collection:
+  title: Files
+  route_name: entity.file.collection
+  parent: system.admin_content
+  description: 'Manage files for your site.'
+
 file_entity.types:
   title: 'File types'
   description: 'Manage settings for the type of files used on your site.'

--- a/file_entity.routing.yml
+++ b/file_entity.routing.yml
@@ -57,6 +57,15 @@ entity.file.add_form:
   options:
     _admin_route: TRUE
 
+entity.file.collection:
+  path: /admin/content/files
+  defaults:
+    _entity_list: 'file'
+    _title: 'Files'
+  requirements:
+    _permission: 'administer files'
+
+
 file_entity.file_add_upload:
   path: /file/add/upload
   defaults:

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -41,8 +41,14 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
     // Avoid 'data' being treated as a field.
     $file_data = $data['data'][0]['value'];
     unset($data['data']);
-    // Decode and save to file.
-    $file_contents = base64_decode($file_data);
+    if ( strpos($file_data, 'http') === 0 ) {
+      // Get the remote file contents.
+      $file_contents = file_get_contents($file_data);
+      $file_data = base64_encode($file_contents);
+    } else {
+      // Decode and save to file.
+      $file_contents = base64_decode($file_data);
+    }
     $entity = parent::denormalize($data, $class, $format, $context);
     $dirname = drupal_dirname($entity->getFileUri());
     file_prepare_directory($dirname, FILE_CREATE_DIRECTORY);

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -41,7 +41,7 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
     // Avoid 'data' being treated as a field.
     $file_data = $data['data'][0]['value'];
     unset($data['data']);
-    if ( strpos($file_data, 'http') === 0 ) {
+    if ( filter_var($file_data, FILTER_VALIDATE_URL) ) {
       // Get the remote file contents.
       $file_contents = file_get_contents($file_data);
       $file_data = base64_encode($file_contents);


### PR DESCRIPTION
On an existing project, when I use file entity with Drupal 8.0.1, I get a WSOD at `admin/content`. Adding this route corrects the issue.
