### PR TITLE
Use the appropriate theme call to render link to show token tree

### DIFF
--- a/src/Form/FileSettingsForm.php
+++ b/src/Form/FileSettingsForm.php
@@ -63,9 +63,8 @@ class FileSettingsForm extends FormBase {
     // Provide default token values.
     if (\Drupal::moduleHandler()->moduleExists('token')) {
       $form['token_help'] = array(
-        '#theme' => 'token_tree',
+        '#theme' => 'token_tree_link',
         '#token_types' => array('file'),
-        '#dialog' => TRUE,
       );
       $form['file_entity_alt']['#description'] .= t('This field supports tokens.');
       $form['file_entity_title']['#description'] .= t('This field supports tokens.');

--- a/src/Plugin/Field/FieldFormatter/FileDownloadLinkFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FileDownloadLinkFormatter.php
@@ -120,9 +120,8 @@ class FileDownloadLinkFormatter extends FileFormatterBase implements ContainerFa
         $token_types[] = $form['#entity_type'];
       }
       $element['token_tree_link'] = array(
-        '#theme' => 'token_tree',
+        '#theme' => 'token_tree_link',
         '#token_types' => $token_types,
-        '#dialog' => TRUE,
       );
     }
 


### PR DESCRIPTION
The dialog option for token browser is not used and is going to be
removed in https://www.drupal.org/node/2640138. This commit changes the
usages to the correct and more appropriate theme function.
