### PR TITLE
Entity browser widget

### DIFF
--- a/config/install/core.entity_view_display.file.audio.thumbnail.yml
+++ b/config/install/core.entity_view_display.file.audio.thumbnail.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.file.thumbnail
+    - file_entity.type.audio
+id: file.audio.thumbnail
+targetEntityType: file
+bundle: audio
+mode: thumbnail
+content:
+  filename:
+    type: string
+    weight: 0
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    label: hidden
+hidden:
+  filemime: true
+  filesize: true
+  uid: true
+  uri: true

--- a/config/install/core.entity_view_display.file.document.thumbnail.yml
+++ b/config/install/core.entity_view_display.file.document.thumbnail.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.file.thumbnail
+    - file_entity.type.document
+id: file.document.thumbnail
+targetEntityType: file
+bundle: document
+mode: thumbnail
+content:
+  filename:
+    type: string
+    weight: 0
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    label: hidden
+hidden:
+  filemime: true
+  filesize: true
+  uid: true
+  uri: true

--- a/config/install/core.entity_view_display.file.image.thumbnail.yml
+++ b/config/install/core.entity_view_display.file.image.thumbnail.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.file.thumbnail
+    - field.field.file.image.field_image_alt_text
+    - field.field.file.image.field_image_title_text
+    - file_entity.type.image
+  module:
+    - file_entity
+id: file.image.thumbnail
+targetEntityType: file
+bundle: image
+mode: thumbnail
+content:
+  filename:
+    type: string
+    weight: 1
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  uri:
+    type: file_image
+    label: hidden
+    weight: 0
+    settings:
+      image_style: thumbnail
+      image_link: ''
+    third_party_settings: {  }
+hidden:
+  field_image_alt_text: true
+  field_image_title_text: true
+  filemime: true
+  filesize: true
+  uid: true

--- a/config/install/core.entity_view_display.file.video.thumbnail.yml
+++ b/config/install/core.entity_view_display.file.video.thumbnail.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.file.thumbnail
+    - file_entity.type.video
+id: file.video.thumbnail
+targetEntityType: file
+bundle: video
+mode: thumbnail
+content:
+  filename:
+    type: string
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  filemime: true
+  filesize: true
+  uid: true
+  uri: true

--- a/config/install/core.entity_view_mode.file.thumbnail.yml
+++ b/config/install/core.entity_view_mode.file.thumbnail.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - file_entity
+id: file.thumbnail
+label: Thumbnail
+targetEntityType: file
+cache: true

--- a/file_entity.module
+++ b/file_entity.module
@@ -210,17 +210,16 @@ function template_preprocess_file(&$variables) {
   $file = $variables['file'];
 
   $variables['id']        = $file->id();
-  $variables['date']      = format_date($file->getCreatedTime()); // @TODO: Check this out
+  $variables['date']      = \Drupal::service('date.formatter')->format($file->getCreatedTime());
   $username = array(
     '#theme' => 'username',
     '#account' => $file->getOwner(),
     '#link_options' => array('attributes' => array('rel' => 'author')),
   );
-  $variables['name']      = drupal_render($username);
+  $variables['name']      = $username;
 
   $variables['file_url']  = $file->url('canonical');
-  $label                  = $file->label();
-  $variables['label']     = \Drupal\Component\Utility\SafeMarkup::checkPlain($label);
+  $variables['label']     = $file->label();
   $variables['page']      = $view_mode == 'full' && $file->isPage();
 
   // Hide the file name from being displayed until we can figure out a better
@@ -231,45 +230,14 @@ function template_preprocess_file(&$variables) {
     $variables['title_attributes_array']['class'][] = 'element-invisible';
   }
 
-  // Flatten the file object's member fields.
-  $variables = array_merge((array) $file, $variables);
-
   // Helpful $content variable for templates.
   $variables += array('content' => array());
   foreach (\Drupal\Core\Render\Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
 
-  // Make the field variables available with the appropriate language.
-  //field_attach_preprocess('file', $file, $variables['content'], $variables);
-
   // Attach the file object to the content element.
   $variables['content']['file']['#file'] = $file;
-
-  // Display post information only on certain file types.
-  //if (variable_get('file_submitted_' . $file->type, FALSE)) { @TODO: What todo with this?
-  if (FALSE) {
-    $variables['display_submitted'] = TRUE;
-    $variables['submitted'] = t('Uploaded by @username on @datetime', array('@username' => $variables['name'], '@datetime' => $variables['date']));
-    $variables['user_picture'] = theme_get_setting('toggle_file_user_picture') ? theme('user_picture', array('account' => $account)) : '';
-  }
-  else {
-    $variables['display_submitted'] = FALSE;
-    $variables['submitted'] = '';
-    $variables['user_picture'] = '';
-  }
-
-  // Gather file classes.
-  $variables['classes_array'][] = Html::getClass('file-' . $file->bundle());
-  $variables['classes_array'][] = Html::getClass('file-' . $file->getMimeType());
-  if (!$file->isPermanent()) {
-    $variables['classes_array'][] = 'file-temporary';
-  }
-
-  // Change the 'file-entity' class into 'file'
-  if ($variables['classes_array'][0] == 'file-entity') {
-    $variables['classes_array'][0] = 'file';
-  }
 }
 
 /**

--- a/src/Entity/FileEntity.php
+++ b/src/Entity/FileEntity.php
@@ -325,10 +325,12 @@ class FileEntity extends File implements FileEntityInterface {
       ))
       ->setDisplayConfigurable('view', TRUE);
 
-    $fields['uid']->setDisplayOptions('view', array(
-      'type' => 'uri_link',
-      'weight' => 1,
-    ))
+    $fields['uid']
+      ->setDisplayOptions('view', array(
+        'type' => 'uri_link',
+        'weight' => 1,
+      ))
+      ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('form', array(
         'type' => 'entity_reference_autocomplete',
         'weight' => -1,
@@ -340,14 +342,18 @@ class FileEntity extends File implements FileEntityInterface {
         )
       ));
 
-    $fields['filemime']->setDisplayOptions('view', array(
-      'type' => 'string',
-      'weight' => 2,
-    ));
-    $fields['filesize']->setDisplayOptions('view', array(
-      'type' => 'file_size',
-      'weight' => 3,
-    ));
+    $fields['filemime']
+      ->setDisplayOptions('view', array(
+        'type' => 'string',
+        'weight' => 2,
+      ))
+      ->setDisplayConfigurable('view', TRUE);
+    $fields['filesize']
+      ->setDisplayOptions('view', array(
+        'type' => 'file_size',
+        'weight' => 3,
+      ))
+      ->setDisplayConfigurable('view', TRUE);
 
     return $fields;
   }

--- a/src/Plugin/Field/FieldWidget/FileEntityBrowser.php
+++ b/src/Plugin/Field/FieldWidget/FileEntityBrowser.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\file_entity\Plugin\Field\FieldWidget\FileEditableWidget.
+ */
+
+namespace Drupal\file_entity\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\SortArray;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\entity_browser\Plugin\Field\FieldWidget\EntityReference;
+
+/**
+ * Entity browser file widget.
+ *
+ * @FieldWidget(
+ *   id = "file_entity_browser",
+ *   label = @Translation("Entity browser (file)"),
+ *   provider = "entity_browser",
+ *   multiple_values = TRUE,
+ *   field_types = {
+ *     "file",
+ *     "image"
+ *   }
+ * )
+ */
+class FileEntityBrowser extends EntityReference {
+
+  /**
+   * Due to the table structure, this widget has a different depth.
+   *
+   * @var int
+   */
+  protected static $deleteDepth = 3;
+
+  /**
+   * @var \Drupal\Core\Field\FieldItemListInterface
+   */
+  protected $items;
+
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $settings = parent::defaultSettings();
+    $settings['view_mode'] = 'thumbnail';
+    return $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = parent::settingsForm($form, $form_state);
+
+    $element['field_widget_display']['#access'] = FALSE;
+    $element['field_widget_display_settings']['#access'] = FALSE;
+
+
+    $element['view_mode'] = [
+      '#title' => t('File view mode'),
+      '#type' => 'select',
+      '#default_value' => $this->getSetting('view_mode'),
+      '#options' => \Drupal::service('entity_display.repository')->getViewModeOptions('file'),
+    ];
+
+    return $element;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $entity_browser_id = $this->getSetting('entity_browser');
+    $view_mode = $this->getSetting('view_mode');
+
+    if (empty($entity_browser_id)) {
+      return [t('No entity browser selected.')];
+    }
+    else {
+      $browser = $this->entityManager->getStorage('entity_browser')
+        ->load($entity_browser_id);
+      $summary[] = t('Entity browser: @browser', ['@browser' => $browser->label()]);
+    }
+
+    if (!empty($view_mode)) {
+      $summary[] = t('View mode: @name', ['@name' => $view_mode]);
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $this->items = $items;
+    return parent::formElement($items, $delta, $element, $form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function displayCurrentSelection($details_id, $field_parents, $entities) {
+
+    $view_mode = $this->getSetting('view_mode');
+
+    $view_builder = \Drupal::entityTypeManager()->getViewBuilder('file');
+    $config = \Drupal::config('file.settings');
+
+    $delta = 0;
+
+    $order_class = $this->fieldDefinition->getName() . '-delta-order';
+
+    $current = [
+      '#type' => 'table',
+      '#header' => [$this->t('Preview'), $this->t('Metadata'), ['data' => $this->t('Operations'), 'colspan' => 2], t('Order', array(), array('context' => 'Sort order'))],
+      '#empty' => $this->t('No files yet'),
+      '#attributes' => ['class' => ['entities-list']],
+      '#tabledrag' => array(
+        array(
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => $order_class,
+        ),
+      ),
+    ];
+    foreach ($entities as $entity) {
+      $display = $view_builder->view($entity, $view_mode);
+
+      // Find the default description.
+      $description = '';
+      $alt = '';
+      $title = '';
+      $weight = $delta;
+      foreach ($this->items as $item) {
+        if ($item->target_id == $entity->id()) {
+          if ($this->fieldDefinition->getType() == 'file') {
+            $description = $item->description;
+          }
+          elseif ($this->fieldDefinition->getType() == 'image') {
+            $alt = $item->alt;
+            $title = $item->title;
+          }
+          $weight = $item->_weight ?: $delta;
+        }
+      }
+
+      $current[$entity->id()] = [
+        '#attributes' => [
+          'class' => ['draggable'],
+          'data-entity-id' => $entity->id()
+        ],
+        'display' => $display,
+        'meta' => [
+          'description' => [
+            '#type' => $config->get('description.type'),
+            '#title' =>$this->t('Description'),
+            '#default_value' => $description,
+            '#maxlength' => $config->get('description.length'),
+            '#description' =>$this->t('The description may be used as the label of the link to the file.'),
+            '#access' => $this->fieldDefinition->getType() == 'file' && $this->fieldDefinition->getSetting('description_field'),
+          ],
+          'alt' => [
+            '#type' => 'textfield',
+            '#title' =>$this->t('Alternative text'),
+            '#default_value' => $alt,
+            '#maxlength' => 512,
+            '#description' =>$this->t('This text will be used by screen readers, search engines, or when the image cannot be loaded.'),
+            '#access' => $this->fieldDefinition->getType() == 'image' && $this->fieldDefinition->getSetting('alt_field'),
+            '#required' => $this->fieldDefinition->getType() == 'image' && $this->fieldDefinition->getSetting('alt_field_required'),
+          ],
+          'title' => [
+            '#type' => 'textfield',
+            '#title' =>$this->t('Title'),
+            '#default_value' => $title,
+            '#maxlength' => 1024,
+            '#description' =>$this->t('The title is used as a tool tip when the user hovers the mouse over the image.'),
+            '#access' => $this->fieldDefinition->getType() == 'image' && $this->fieldDefinition->getSetting('title_field'),
+            '#required' => $this->fieldDefinition->getType() == 'image' && $this->fieldDefinition->getSetting('title_field_required'),
+          ],
+        ],
+        'edit_button' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Edit'),
+          '#ajax' => [
+            'url' => Url::fromRoute('entity_browser.edit_form', ['entity_type' => $entity->getEntityTypeId(), 'entity' => $entity->id()])
+          ],
+          '#access' => (bool) $this->getSetting('field_widget_edit')
+        ],
+        'remove_button' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Remove'),
+          '#ajax' => [
+            'callback' => [get_class($this), 'updateWidgetCallback'],
+            'wrapper' => $details_id,
+          ],
+          '#submit' => [[get_class($this), 'removeItemSubmit']],
+          '#name' => $this->fieldDefinition->getName() . '_remove_' . $entity->id(),
+          '#limit_validation_errors' => [array_merge($field_parents, [$this->fieldDefinition->getName()])],
+          '#attributes' => ['data-entity-id' => $entity->id()],
+          '#access' => (bool) $this->getSetting('field_widget_remove')
+        ],
+        '_weight' => [
+          '#type' => 'weight',
+          '#title' => $this->t('Weight for row @number', array('@number' => $delta + 1)),
+          '#title_display' => 'invisible',
+          // Note: this 'delta' is the FAPI #type 'weight' element's property.
+          '#delta' => count($entities),
+          '#default_value' => $weight,
+          '#attributes' => ['class' => array($order_class)],
+        ],
+      ];
+
+      $delta++;
+    }
+
+    return $current;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $ids = empty($values['target_id']) ? [] : explode(' ', trim($values['target_id']));
+    $return = [];
+    foreach ($ids as $id) {
+      $item_values = [
+        'target_id' => $id,
+        '_weight' => $values['current'][$id]['_weight'],
+      ];
+      if ($this->fieldDefinition->getType() == 'file' && isset($values['current'][$id]['meta']['description'])) {
+        $item_values['description'] = $values['current'][$id]['meta']['description'];
+      }
+      if ($this->fieldDefinition->getType() == 'image' && isset($values['current'][$id]['meta']['alt'])) {
+        $item_values['alt'] = $values['current'][$id]['meta']['alt'];
+      }
+      if ($this->fieldDefinition->getType() == 'image' && isset($values['current'][$id]['meta']['title'])) {
+        $item_values['title'] = $values['current'][$id]['meta']['title'];
+      }
+      $return[] = $item_values;
+    }
+
+    // Return ourself as the structure doesn't match the default.
+    usort($return, function ($a, $b) {
+      return SortArray::sortByKeyInt($a, $b, '_weight');
+    });
+
+    return array_values($return);
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/FileEntityBrowser.php
+++ b/src/Plugin/Field/FieldWidget/FileEntityBrowser.php
@@ -7,7 +7,6 @@
 namespace Drupal\file_entity\Plugin\Field\FieldWidget;
 
 use Drupal\Component\Utility\SortArray;
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -41,8 +40,6 @@ class FileEntityBrowser extends EntityReference {
    */
   protected $items;
 
-
-
   /**
    * {@inheritdoc}
    */
@@ -61,7 +58,6 @@ class FileEntityBrowser extends EntityReference {
     $element['field_widget_display']['#access'] = FALSE;
     $element['field_widget_display_settings']['#access'] = FALSE;
 
-
     $element['view_mode'] = [
       '#title' => t('File view mode'),
       '#type' => 'select',
@@ -70,7 +66,6 @@ class FileEntityBrowser extends EntityReference {
     ];
 
     return $element;
-
   }
 
   /**

--- a/templates/file.html.twig
+++ b/templates/file.html.twig
@@ -1,21 +1,22 @@
-<div id="{{ id }}" class="{{ classes }}"{{ attributes }}>
+{%
+  set classes = [
+  'file',
+  'file--type-' ~ file.bundle|clean_class,
+  'file--mimetype-' ~ file.getMimeType|clean_class,
+  not file.isPermanent() ? 'file--temporary',
+  view_mode ? 'file--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
 
   {{ title_prefix }}
-  {% if not page %}
+  {% if not page and not view_mode == 'thumbnail' %}
     <h2 {{ title_attributes }}><a href="{{ file_url }}">{{ label }}</a></h2>
   {% endif %}
   {{ title_suffix }}
 
-  {% if display_submitted %}
-    <div class="submitted">
-      {{ submitted }}
-    </div>
-  {% endif %}
-
   <div class="content"{{ content_attributes }}>
-      {{ content|without('links') }}
+      {{ content }}
   </div>
-
-  {{ content.links }}
 
 </div>


### PR DESCRIPTION
This adds an entity browser widget that allows to select and upload files through an entity browser. Quite a few changes beside the widget itself to make it nicer.

This depends on https://github.com/drupal-media/entity_browser/pull/134, which will need to be merged first.
- The Widget class itself. Supports description field (will add alt/title for images and the show checkbox later). I replaced the selection display plugin with specific code that displays each file in a table, with preview, the fields and buttons to edit and delete, just like in the default class. Reordering is also supported.
- Adds a Thumbnail view mode and view display configurations and some changes to base fields to be able to hide everything except image/name. We don't have a good way to show something for videos/audios right now, though. But the view based display is quite flexible, in my project, I'm for example showing a preview image field for videos. We can also made video/audio formatters visible in there but not sure if that makes sense. Maybe we should have a formatter that displays nothing but the mime icon.
- Template and preprocess cleanup, throwing out a lot of cruft from nodes and 7.x, so that the thumbnail preview looks clean.

![selection_016](https://cloud.githubusercontent.com/assets/40826/12115461/d61d371e-b3b2-11e5-9e6f-c68636ea909f.png)
