### PR TITLE
Issue #2818727 by killua99: Fix incorrect project dependency in file_entity.info.yml

### DIFF
--- a/file_entity.info.yml
+++ b/file_entity.info.yml
@@ -4,10 +4,10 @@ description: "Extends Drupal file entities to be fieldable and viewable."
 package: Media
 core: 8.x
 dependencies:
-  - core:file
-  - core:text
-  - core:views
-  - core:image
+  - drupal:file
+  - drupal:text
+  - drupal:views
+  - drupal:image
   - token:token
 configure: file_entity.settings
 test_dependencies:


### PR DESCRIPTION
Trying to use file_entity with Drupal 8.2 is quite impossible, the dependencies are broken.
